### PR TITLE
Changed the api call format

### DIFF
--- a/controllers/image.js
+++ b/controllers/image.js
@@ -1,7 +1,7 @@
 // this is new
 const Clarifai = require('clarifai');
 const app = new Clarifai.App({
-  apiKey: '29c6d9a7a94444cca0059bca356af8c1',
+  apiKey: '2b3cddc9a4134b3dafa87ca2056f55f6',
 });
 
 const handleApiCall = (req, res) => {

--- a/controllers/image.js
+++ b/controllers/image.js
@@ -1,39 +1,37 @@
-
-// this is new 
-const Clarifai = require("clarifai")
+// this is new
+const Clarifai = require('clarifai');
 const app = new Clarifai.App({
-  apiKey: '2b3cddc9a4134b3dafa87ca2056f55f6'
+  apiKey: '29c6d9a7a94444cca0059bca356af8c1',
 });
 
 const handleApiCall = (req, res) => {
-  // const { input } = req.body;
-  // if (!input) {
-  //   return res.status(400).json('invalid request');
-  // }
   app.models
-    .predict(Clarifai.FACE_DETECT_MODEL, req.body.input)
-    .then(data => {
-      res.json(data);
+    .predict(
+      {
+        id: 'a403429f2ddf4b49b307e318f00e528b',
+        version: '34ce21a40cc24b6b96ffee54aabff139',
+      },
+      req.body.input
+    )
+    .then((response) => {
+      res.json(response);
     })
-    .catch(err => {
-      console.log(err);
-      res.status(400).json('unable to work with API');
-    });
+    .catch((err) => res.status(400).json('unable to work with api'));
 };
-
 const handleImage = (req, res, db) => {
   const { id } = req.body;
-  console.log(req.body)
-  db('users').where('id', '=', id)
-    .increment('entries', 1,)
+
+  db('users')
+    .where('id', '=', id)
+    .increment('entries', 1)
     .returning('entries')
-    .then(entries => {
-      res.json(entries[0].entries)
+    .then((entries) => {
+      res.json(entries[0].entries);
     })
-    .catch(err => res.status(400).json('unable to get count for entries'))
-}
+    .catch((err) => res.status(400).json('unable to get count for entries'));
+};
 
 module.exports = {
   handleImage,
-  handleApiCall
+  handleApiCall,
 };


### PR DESCRIPTION
The only change I made on the back end is how to call the clarifai api in image.js. I used this method of specifying the model's id and version. 

instead of 
```
 .predict(Clarifai.FACE_DETECT_MODEL, req.body.input)
    .then(data => {
      res.json(data);
```

I used this format 
   ```
 .predict(
      {
        id: 'a403429f2ddf4b49b307e318f00e528b',
        version: '34ce21a40cc24b6b96ffee54aabff139',
      },
      req.body.input
    )
    .then((response) => {
      res.json(response);
```